### PR TITLE
Created experimental haptics helper class

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/GamePad.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/GamePad.java
@@ -53,12 +53,15 @@ public class GamePad{
         public int triggerLockoutInterval = 20;
         public int joystickButtonLockoutInterval = 300;
         public int joystickLockoutInterval = 20;  // should be Small
-
     }
 
+    /*
+    Accessible HapticsController inside of GamePad class
+    Based on GamepadHaptics class
+     */
+    public GamepadHaptics HapticsController;
+
     public static Params PARAMS = new Params();
-
-
 
     public enum GameplayInputType {
         NONE("No Input"),
@@ -139,6 +142,7 @@ public class GamePad{
     // Class Constructor
     public GamePad(@NonNull Gamepad gp) {
         this.inputGPad = gp;
+        this.HapticsController = new GamepadHaptics(this.inputGPad);
     }
 
     // Telemetry Data Getters

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/GamepadHaptics.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/GamepadHaptics.java
@@ -3,6 +3,8 @@ package org.firstinspires.ftc.teamcode.Helper;
 import androidx.annotation.NonNull;
 import com.qualcomm.robotcore.hardware.Gamepad;
 
+import org.firstinspires.ftc.robotcore.external.Telemetry;
+
 import java.util.ArrayList;
 
 public class GamepadHaptics {
@@ -29,6 +31,13 @@ public class GamepadHaptics {
             res.add(log.getLog());
         }
         return res;
+    }
+
+    public void logTelemetry(Telemetry telemetry) {
+        for (String log : this.getLogs()){
+            telemetry.addLine(log);
+        }
+        telemetry.update();
     }
 
     public void runShortHaptic() {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/GamepadHaptics.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/GamepadHaptics.java
@@ -1,0 +1,58 @@
+package org.firstinspires.ftc.teamcode.Helper;
+
+import androidx.annotation.NonNull;
+import com.qualcomm.robotcore.hardware.Gamepad;
+
+import java.util.ArrayList;
+
+public class GamepadHaptics {
+    private final Gamepad gpInput;
+    private ArrayList<HapticLogs> logs;
+
+    public GamepadHaptics(@NonNull Gamepad gpInput) {
+        this.gpInput = gpInput;
+    }
+
+    private void addTelemetry(String log) {
+        HapticLogs newLog = new HapticLogs(log);
+        this.logs.add(newLog);
+    }
+
+    public void clearTelemetry() {
+        // clear logs by setting empty arraylist
+        this.logs = new ArrayList<>();
+    }
+
+    public ArrayList<String> getLogs() {
+        ArrayList<String> res = new ArrayList<String>();
+        for ( HapticLogs log : this.logs) {
+            res.add(log.getLog());
+        }
+        return res;
+    }
+
+    public void runShortHaptic() {
+        this.addTelemetry("Controller ran short haptic");
+        this.gpInput.rumble(1, 0, 150);
+    }
+
+    public void runMediumHaptic() {
+        this.addTelemetry("Controller ran medium haptic");
+        this.gpInput.rumble(1.5, 0, 350);
+    }
+
+    public void runLongHaptic() {
+        this.addTelemetry("Controller ran long haptic");
+        this.gpInput.rumble(3, 0, 650);
+    }
+
+    public void runCustomHaptic(float r1, float r2, int duration) {
+        this.addTelemetry("Controller ran rumble haptic with values ["+r1+","+r2+","+duration+"]");
+        this.gpInput.rumble(r1, r2, duration);
+    }
+
+    public void runCustomBlip(int count) {
+        this.addTelemetry("Controller ran rumbleBlip haptic with value ["+count+"]");
+        this.gpInput.rumbleBlips(count);
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/HapticLogs.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/HapticLogs.java
@@ -1,0 +1,12 @@
+package org.firstinspires.ftc.teamcode.Helper;
+
+public class HapticLogs {
+    private final String log;
+    public HapticLogs(String log) {
+        this.log = log;
+    }
+
+    public String getLog() {
+        return this.log;
+    }
+}


### PR DESCRIPTION
Created an experimental haptics helper class - just to get a feel of the haptics controller and the `GamePad` class.

A new `GamepadHaptics` class was created, which handles the haptics of a controller + stores controller telemetry logs.

`GamepadHaptics` is stored in `GamePad` as `HapticsController` - so it can be accessed without having to manually instantiate a new instance

Ex:
`this.gpInput.HapticsController.runShortHaptic();`