### PR TITLE
added experimental eventbus system

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/EventBus.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/EventBus.java
@@ -51,7 +51,7 @@ public class EventBus {
         subscribers.remove(subId);
     }
 
-    public void emit(Set<String> events) {
+    public void emit(Set<String> events, Object ... params) {
         for (Map.Entry<String, Class<? extends Subscriber<?>>> entry : this.subscribers.entrySet()) {
             String subId = entry.getKey();
             Class<? extends Subscriber<?>> subscriberClass = entry.getValue();
@@ -60,7 +60,7 @@ public class EventBus {
                 try {
                     Subscriber<?> subscriberInstance = subscriberClass.getDeclaredConstructor().newInstance();
 
-                    subscriberInstance.onMessage();
+                    subscriberInstance.onMessage(params);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/EventBus.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/EventBus.java
@@ -20,6 +20,13 @@ class TestSub implements Subscriber<Void> {
     }
 }
 
+// for parameters in the Subscriber extension:
+abstract class SubWithParams implements Subscriber<String> {
+    public String onMessage(String name) {
+        return "Hello"+name;
+    }
+}
+
 // add a subscription of id 'telemetry'
 EventBus.getInstance().subscribe("telemetry", TestSub.class);
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/EventBus.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/EventBus.java
@@ -1,0 +1,70 @@
+package org.firstinspires.ftc.teamcode.Helper;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashSet;
+
+/*
+example use:
+
+use EventBus.getInstance() to retrieve the singleton instance of the EventBus
+
+// you can edit return of onMessage when instantiating
+class TestSub implements Subscriber<Void> {
+    @Override
+    public Void onMessage() {
+        // add ur onMessage code here
+
+        return null;
+    }
+}
+
+// add a subscription of id 'telemetry'
+EventBus.getInstance().subscribe("telemetry", TestSub.class);
+
+// emitting a new event
+Set<String> targets = new HashSet<>();
+targets.add("telemetry"); // add a new string to `targets` for each subId you want to activate
+EventBus.getInstance().emit(targets);
+
+ */
+
+public class EventBus {
+    private static final EventBus instance = new EventBus();
+
+    private final Map<String, Class<? extends Subscriber<?>>> subscribers = new HashMap<>();
+
+    public EventBus() {
+
+    }
+
+    public static EventBus getInstance() {
+        return instance;
+    }
+
+    public void subscribe(String subId, Class<? extends Subscriber<?>> sub) {
+        subscribers.computeIfAbsent(subId, k -> sub);
+    }
+
+    public void unsubscribe(String subId) {
+        subscribers.remove(subId);
+    }
+
+    public void emit(Set<String> events) {
+        for (Map.Entry<String, Class<? extends Subscriber<?>>> entry : this.subscribers.entrySet()) {
+            String subId = entry.getKey();
+            Class<? extends Subscriber<?>> subscriberClass = entry.getValue();
+
+            if (events.contains(subId)) {
+                try {
+                    Subscriber<?> subscriberInstance = subscriberClass.getDeclaredConstructor().newInstance();
+
+                    subscriberInstance.onMessage();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/Subscriber.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/Subscriber.java
@@ -1,5 +1,7 @@
 package org.firstinspires.ftc.teamcode.Helper;
 
 public interface Subscriber<T> {
-    public T onMessage(Object ... keys);
+    public T onMessage(Object ...params);
+
+    public T onMessage();
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/Subscriber.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/Subscriber.java
@@ -1,0 +1,5 @@
+package org.firstinspires.ftc.teamcode.Helper;
+
+public interface Subscriber<T> {
+    public T onMessage(Object ... keys);
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Tests/TestRoadRunner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Tests/TestRoadRunner.java
@@ -32,7 +32,6 @@ public class TestRoadRunner extends LinearOpMode {
         telemetry.addLine("v0.1");
         telemetry.update();
 
-
         telemetry.addLine(mecanumDrive.pose.heading.toString());
         telemetry.update();
 


### PR DESCRIPTION
Added an experimental EventBus which can help decouple components without the need for dependency injections

example use:

```java
// use EventBus.getInstance() to retrieve the singleton instance of the EventBus

// you can edit return of onMessage when instantiating
class TestSub implements Subscriber<Void> {
    @Override
    public Void onMessage() {
        // add ur onMessage code here

        return null;
    }
}

// add a subscription of id 'telemetry'
EventBus.getInstance().subscribe("telemetry", TestSub.class);

// emitting a new event
Set<String> targets = new HashSet<>();
targets.add("telemetry"); // add a new string to `targets` for each subId you want to activate
EventBus.getInstance().emit(targets);
```
