### PR TITLE
added experimental dependency injection framework

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/DependencyInjection/DependencyInjector.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/DependencyInjection/DependencyInjector.java
@@ -1,0 +1,45 @@
+package org.firstinspires.ftc.teamcode.Helper.DependencyInjection;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class DependencyInjector {
+    private static final Map<String, Object> cache = new HashMap<>();
+
+    public static void register(String name, Object instance) {
+        cache.put(name, instance);
+    }
+
+    public static Object resolve(String name) throws Exception {
+        if (!cache.containsKey(name)) {
+            throw new Exception("No cached dependency found for: " + name);
+        }
+        return cache.get(name);
+    }
+
+    public static void inject(Object obj) throws Exception {
+        Class<?> clazz = obj.getClass();
+
+        for (Field field : clazz.getDeclaredFields()) {
+            if (field.isAnnotationPresent(Inject.class)) {
+                Inject inject = field.getAnnotation(Inject.class);
+
+                assert inject != null;
+                String cacheName = inject.value();
+
+                Object dependency = resolve(cacheName);
+
+                if (!field.getType().isInstance(dependency)) {
+                    throw new Exception("Type mismatch: Cannot assign " + dependency.getClass().getName() +
+                            " to field " + field.getName() + " of type " + field.getType().getName()+": "+"Occurred in Injectable \""+cacheName+"\"");
+                }
+
+                field.setAccessible(true);
+
+                field.set(obj, dependency);
+            }
+        }
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/DependencyInjection/Inject.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/DependencyInjection/Inject.java
@@ -1,0 +1,12 @@
+package org.firstinspires.ftc.teamcode.Helper.DependencyInjection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Inject {
+    String value();
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/DependencyInjection/Instructions.MD
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Helper/DependencyInjection/Instructions.MD
@@ -1,0 +1,52 @@
+Added new Dependency Injection framework which can be used to decouple dependencies without requiring the `EventBus`
+
+Usage:
+
+(example here shown with an ArrayList of strings)
+
+```java
+class Test {
+    // add the @Inject annotation above fields you want to be injected
+    @Inject("values")
+    List<String> vals = new ArrayList<>();
+
+    public Test() throws Exception {
+        // use the inject method to populate fields with cached dependencies
+        DependencyInjector.inject(this);
+    }
+
+   public void print() {
+        for (String val : vals) {
+            System.out.println(val);
+        }
+    }
+}
+```
+
+```java
+class Loader {
+        public static void load() {
+                List<String> vals = new ArrayList<>();
+                vals.add("val 1");
+                vals.add("val 2");
+                vals.add("val 3");
+        
+                DependencyInjector.register("values", vals);
+        }
+}
+```
+
+```java
+class Example extends LinearOpMode {
+    void runOpMode() {
+        waitForStart();
+        Loader.load();
+        try {
+           Test test = new Test();
+           test.print();
+        } catch(Exception e) {}
+    }
+}
+```
+
+This will print out the values in order (from the ArrayList). The main point here is that nothing was passed from `Example` to `Test` when instantiation occurred. Instead, the `Loader` caches the `ArrayList` of values, and the dependency injectors injects the corresponding dependencies into `Test` as required - this approach is much better at following SOLID principles.  Now, `Test` has no information about how or what created the `ArrayList`, and it does not to  modify or overload its constructor parameters in order to get the dependency. A dedicated class (Like `Loader`) can handle caching dependencies, and these are injected into the needed class.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Tests/DITest/LEDTestDI.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Tests/DITest/LEDTestDI.java
@@ -1,0 +1,67 @@
+package org.firstinspires.ftc.teamcode.Tests.DITest;
+
+/*
+This file is an LED TEST FILE - Which is used to test the TelemetryEvent class
+ */
+
+
+import com.acmerobotics.roadrunner.Line;
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.eventloop.opmode.OpMode;
+
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+import com.qualcomm.robotcore.hardware.DigitalChannel;
+import com.qualcomm.robotcore.hardware.LED;
+
+import org.firstinspires.ftc.robotcore.external.Telemetry;
+import org.firstinspires.ftc.teamcode.Helper.DependencyInjection.DependencyInjector;
+import org.firstinspires.ftc.teamcode.Helper.EventBus.EventBus;
+import org.firstinspires.ftc.teamcode.Helper.Telemetry.TelemetryEvent;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@TeleOp(name = "Concept: RevLED", group = "Concept")
+
+public class LEDTestDI extends LinearOpMode {
+    LED frontLED_red;
+    LED frontLED_green;
+    TelemetryTest tester = null;
+
+    public void runOpMode() {
+        DependencyInjector.register("telemetry", telemetry);
+
+        try {
+            this.tester = new TelemetryTest();
+        } catch(Exception e) {
+            //
+        }
+
+        frontLED_green = hardwareMap.get(LED.class, "front_led_green");
+        frontLED_red = hardwareMap.get(LED.class, "front_led_red");
+
+        waitForStart();
+
+        while (opModeIsActive()) {
+            if (gamepad1.a) {
+                frontLED_red.on();
+
+                if (this.tester != null) {
+                    this.tester.logRedOn();
+                }
+
+            } else {
+                frontLED_red.off();
+
+                if (this.tester != null) {
+                    this.tester.logRedOff();
+                }
+            }
+            if (gamepad1.b) {
+                frontLED_green.on();
+            } else {
+                frontLED_green.off();
+            }
+        }
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Tests/DITest/TelemetryTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Tests/DITest/TelemetryTest.java
@@ -1,0 +1,28 @@
+package org.firstinspires.ftc.teamcode.Tests.DITest;
+
+import org.firstinspires.ftc.robotcore.external.Telemetry;
+import org.firstinspires.ftc.teamcode.Helper.DependencyInjection.DependencyInjector;
+import org.firstinspires.ftc.teamcode.Helper.DependencyInjection.Inject;
+
+public class TelemetryTest {
+    @Inject("telemetry")
+    Telemetry telemetry = null;
+
+    public TelemetryTest() throws Exception {
+        DependencyInjector.inject(this);
+    }
+
+    public void logRedOn() {
+        if (this.telemetry != null) {
+            this.telemetry.addLine("Red Light On");
+            this.telemetry.update();
+        }
+    }
+
+    public void logRedOff() {
+        if (this.telemetry != null) {
+            this.telemetry.addLine("Red Light Off");
+            this.telemetry.update();
+        }
+    }
+}


### PR DESCRIPTION
Added new Dependency Injection framework which can be used to decouple dependencies without requiring the `EventBus`

Usage:

(example here shown with an ArrayList of strings)

```java
class Test {
    // add the @Inject annotation above fields you want to be injected
    @Inject("values")
    List<String> vals = new ArrayList<>();

    public Test() throws Exception {
        // use the inject method to populate fields with cached dependencies
        DependencyInjector.inject(this);
    }

   public void print() {
        for (String val : vals) {
            System.out.println(val);
        }
    }
}
```

```java
class Loader {
        public static void load() {
                List<String> vals = new ArrayList<>();
                vals.add("val 1");
                vals.add("val 2");
                vals.add("val 3");
        
                DependencyInjector.register("values", vals);
        }
}
```

```java
class Example extends LinearOpMode {
    void runOpMode() {
        waitForStart();
        Loader.load();
        try {
           Test test = new Test();
           test.print();
        } catch(Exception e) {}
    }
}
```

This will print out the values in order (from the ArrayList). The main point here is that nothing was passed from `Example` to `Test` when instantiation occurred. Instead, the `Loader` caches the `ArrayList` of values, and the dependency injectors injects the corresponding dependencies into `Test` as required - this approach is much better at following SOLID principles.  Now, `Test` has no information about how or what created the `ArrayList`, and it does not to  modify or overload its constructor parameters in order to get the dependency. A dedicated class (Like `Loader`) can handle caching dependencies, and these are injected into the needed class.